### PR TITLE
upcase module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-Nyudl::Mdi::Worker
+NYUDL::MDI::Worker
 ==================
 
 ## Overview
-Worker class(es) for a Message Driven Infrastructure
+Worker base class for New York University Digital Library (NYUDL)
+Message-Driven Infrastructure (MDI).
 
 ## Status
 in development

--- a/lib/nyudl/mdi/worker.rb
+++ b/lib/nyudl/mdi/worker.rb
@@ -1,7 +1,7 @@
 require "nyudl/mdi/worker/version"
 
-module Nyudl
-  module Mdi
+module NYUDL
+  module MDI
     module Worker
       # Your code goes here...
     end

--- a/lib/nyudl/mdi/worker/version.rb
+++ b/lib/nyudl/mdi/worker/version.rb
@@ -1,5 +1,5 @@
-module Nyudl
-  module Mdi
+module NYUDL
+  module MDI
     module Worker
       VERSION = "0.1.0"
     end

--- a/nyudl-mdi-worker.gemspec
+++ b/nyudl-mdi-worker.gemspec
@@ -5,7 +5,7 @@ require 'nyudl/mdi/worker/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "nyudl-mdi-worker"
-  spec.version       = Nyudl::Mdi::Worker::VERSION
+  spec.version       = NYUDL::MDI::Worker::VERSION
   spec.authors       = ["jgpawletko"]
   spec.email         = ["jgpawletko@gmail.com"]
 


### PR DESCRIPTION
Change module names from 'Nyudl::Mdi' to 'NYUDL::MDI' thereby
following the Ruby Style Guide recommendation to [use uppercase
letters for acronyms](https://github.com/bbatsov/ruby-style-guide#camelcase-classes).
